### PR TITLE
Add options to build on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
 endif(APPLE)
 
+if(UNIX AND NOT APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+endif(UNIX AND NOT APPLE)
+
 find_package(OpenCV REQUIRED)
 set(LIBS ${OpenCV_LIBS})
 


### PR DESCRIPTION
Duplicate of the APPLE linux and add `-fPIC` which seems to be needed when built using `dwango_opentoonz_plugins`
